### PR TITLE
Rename Notifications.delay to .interval

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -67,7 +67,7 @@ class ChecksController < ApplicationController
 
   def check_params(*others)
     params.require(:check).permit(:domain, :domain_created_at, :comment, :vendor, *others,
-      notifications_attributes: [:id, :channel, :recipient, :delay])
+      notifications_attributes: [:id, :channel, :recipient, :interval])
   end
 
   def build_empty_notification

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -35,7 +35,7 @@ class NotificationsController < ApplicationController
   end
 
   def notification_params
-    params.require(:notification).permit(:channel, :recipient, :delay)
+    params.require(:notification).permit(:channel, :recipient, :interval)
   end
 
   def check_path

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -32,7 +32,7 @@ class Check < ApplicationRecord
   has_many :notifications, validate: true, dependent: :destroy
   accepts_nested_attributes_for :notifications,
     allow_destroy: true,
-    reject_if: lambda { |at| at["recipient"].blank? && at["delay"].blank? }
+    reject_if: lambda { |at| at["recipient"].blank? && at["interval"].blank? }
 
   enum kind: [:domain, :ssl]
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  channel    :integer          default("email"), not null
-#  delay      :integer          not null
+#  interval   :integer          not null
 #  recipient  :string(255)      not null
 #  sent_at    :datetime
 #  status     :integer          default("pending"), not null
@@ -28,7 +28,7 @@ class Notification < ApplicationRecord
   enum status: [:pending, :ongoing, :succeed, :failed]
 
   validates :channel, presence: true
-  validates :delay, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
+  validates :interval, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
   validates :recipient, presence: true
 
   scope :active_check, -> { Check.active }

--- a/app/services/notifier/resolver.rb
+++ b/app/services/notifier/resolver.rb
@@ -4,7 +4,7 @@ module Notifier
       scope
         .where("checks.domain_expires_at >= CURDATE()")
         .where("DATE(checks.domain_expires_at)
-          <= DATE_ADD(CURDATE(), INTERVAL notifications.delay DAY)")
+          <= DATE_ADD(CURDATE(), INTERVAL notifications.interval DAY)")
     end
 
     def resolve_check_failed

--- a/app/views/notifications/_nested_form.html.erb
+++ b/app/views/notifications/_nested_form.html.erb
@@ -15,7 +15,7 @@
     </div>
 
     <div class="form-group col-md-2">
-      <%= f.input :delay, as: :integer, label: false %>
+      <%= f.input :interval, as: :integer, label: false %>
     </div>
 
     <div class="form-group col-md-1">

--- a/app/views/notifications/_nested_form_headers.html.erb
+++ b/app/views/notifications/_nested_form_headers.html.erb
@@ -10,6 +10,6 @@
   </div>
 
   <div class="col-md-2">
-    <%= f.label :delay %>
+    <%= f.label :interval %>
   </div>
 </div>

--- a/app/views/notifications_mailer/_footer_expires_soon.en.html.erb
+++ b/app/views/notifications_mailer/_footer_expires_soon.en.html.erb
@@ -3,7 +3,7 @@
 --
 
 <p>
-  You received this email because of the notification <%= delay %> days before the expiry date.<br />
+  You received this email because of the notification <%= interval %> days before the expiry date.<br />
   You can handle the notifications for this check by following this link:<br />
   <%= link_to nil, edit_check_url(check) %>
 </p>

--- a/app/views/notifications_mailer/_footer_expires_soon.en.text.erb
+++ b/app/views/notifications_mailer/_footer_expires_soon.en.text.erb
@@ -1,6 +1,6 @@
 --
 
-You received this email because of the notification <%= delay %> days before the expiry date.
+You received this email because of the notification <%= interval %> days before the expiry date.
 You can handle the notifications for this check by following this link:
 <%= edit_check_url(check) %>
 

--- a/app/views/notifications_mailer/_footer_recurrent_failures.en.html.erb
+++ b/app/views/notifications_mailer/_footer_recurrent_failures.en.html.erb
@@ -2,7 +2,7 @@
 <br />
 --
 
-<p>You received this email because of the notification <%= delay %> days before
+<p>You received this email because of the notification <%= interval %> days before
 the last known expiry date.<br />
 You can handle the check by following this link: <br />
 <%= link_to nil, edit_check_url(check) %>

--- a/app/views/notifications_mailer/_footer_recurrent_failures.en.text.erb
+++ b/app/views/notifications_mailer/_footer_recurrent_failures.en.text.erb
@@ -1,6 +1,6 @@
 --
 
-You received this email because of the notification <%= delay %> days before
+You received this email because of the notification <%= interval %> days before
 the last known expiry date.
 You can handle the check by following this link:
 <%= edit_check_url(check) %>

--- a/app/views/notifications_mailer/domain_expires_soon.en.html.erb
+++ b/app/views/notifications_mailer/domain_expires_soon.en.html.erb
@@ -9,4 +9,4 @@
 
 <%= render "check_comment_vendor" %>
 
-<%= render "footer_expires_soon", delay: @notification.delay, check: @check %>
+<%= render "footer_expires_soon", interval: @notification.interval, check: @check %>

--- a/app/views/notifications_mailer/domain_expires_soon.en.text.erb
+++ b/app/views/notifications_mailer/domain_expires_soon.en.text.erb
@@ -6,4 +6,4 @@ the domain <%= @check.domain %> will expire <%= format_utc(@check.domain_expires
 <%= render "check_comment_vendor" %>
 
 
-<%= render "footer_expires_soon", delay: @notification.delay, check: @check %>
+<%= render "footer_expires_soon", interval: @notification.interval, check: @check %>

--- a/app/views/notifications_mailer/domain_recurrent_failures.en.html.erb
+++ b/app/views/notifications_mailer/domain_recurrent_failures.en.html.erb
@@ -22,4 +22,4 @@ or delete the check by following this link: <br /><br />
 <%= render "check_comment_vendor" %>
 
 
-<%= render "footer_recurrent_failures", delay: @notification.delay, check: @check %>
+<%= render "footer_recurrent_failures", interval: @notification.interval, check: @check %>

--- a/app/views/notifications_mailer/domain_recurrent_failures.en.text.erb
+++ b/app/views/notifications_mailer/domain_recurrent_failures.en.text.erb
@@ -13,4 +13,4 @@ or delete the check by following this link:
 
 <%= render "check_comment_vendor" %>
 
-<%= render "footer_recurrent_failures", delay: @notification.delay, check: @check %>
+<%= render "footer_recurrent_failures", interval: @notification.interval, check: @check %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
+  # This option may cause significant intervals in view rendering with a large
   # number of complex assets.
   config.assets.debug = true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,4 +58,4 @@ en:
     form:
       notifications_hint: |
         Receive notifications to warn you when our system detects that the
-        expiration date is coming. The delay is set in number of days.
+        expiration date is coming. The time is set in number of days.

--- a/db/migrate/20180605203552_rename_notifications_delay_to_interval.rb
+++ b/db/migrate/20180605203552_rename_notifications_delay_to_interval.rb
@@ -1,5 +1,5 @@
-class RenameNotificationsintervalToInterval < ActiveRecord::Migration[5.2]
+class RenameNotificationsDelayToInterval < ActiveRecord::Migration[5.2]
   def change
-    rename_column :notifications, :interval, :interval
+    rename_column :notifications, :delay, :interval
   end
 end

--- a/db/migrate/20180605203552_rename_notifications_delay_to_interval.rb
+++ b/db/migrate/20180605203552_rename_notifications_delay_to_interval.rb
@@ -1,0 +1,5 @@
+class RenameNotificationsintervalToInterval < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :notifications, :interval, :interval
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2018_06_13_055303) do
     t.bigint "check_id"
     t.integer "channel", default: 0, null: false
     t.string "recipient", null: false
-    t.integer "delay", null: false
+    t.integer "interval", null: false
     t.integer "status", default: 0, null: false
     t.datetime "sent_at"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -35,7 +35,7 @@ check_chexpire_org_error = Check.create!(
 
 Notification.create!(
   check: check_chexpire_org,
-  delay: 15,
+  interval: 15,
   channel: :email,
   recipient: "colin@example.org",
   status: :pending,
@@ -43,7 +43,7 @@ Notification.create!(
 
 Notification.create!(
   check: check_chexpire_org_error,
-  delay: 15,
+  interval: 15,
   channel: :email,
   recipient: "colin@example.org",
   status: :pending,

--- a/test/factories/notifications.rb
+++ b/test/factories/notifications.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  channel    :integer          default("email"), not null
-#  interval      :integer          not null
+#  interval   :integer          not null
 #  recipient  :string(255)      not null
 #  sent_at    :datetime
 #  status     :integer          default("pending"), not null

--- a/test/factories/notifications.rb
+++ b/test/factories/notifications.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  channel    :integer          default("email"), not null
-#  delay      :integer          not null
+#  interval      :integer          not null
 #  recipient  :string(255)      not null
 #  sent_at    :datetime
 #  status     :integer          default("pending"), not null
@@ -24,7 +24,7 @@
 FactoryBot.define do
   factory :notification do
     check
-    delay 30
+    interval 30
     channel :email
     recipient "recipient@domain.fr"
     status :pending

--- a/test/mailers/notifications_mailer_test.rb
+++ b/test/mailers/notifications_mailer_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class NotificationsMailerTest < ActionMailer::TestCase
   test "domain_expires_soon" do
     check = create(:check, domain_expires_at: Time.new(2018, 6, 10, 12, 0, 5, "+02:00"))
-    notification = build(:notification, delay: 10, check: check, recipient: "colin@example.org")
+    notification = build(:notification, interval: 10, check: check, recipient: "colin@example.org")
 
     Date.stub :today, Date.new(2018, 6, 2) do
       mail = NotificationsMailer.with(notification: notification).domain_expires_soon

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  channel    :integer          default("email"), not null
-#  interval      :integer          not null
+#  interval   :integer          not null
 #  recipient  :string(255)      not null
 #  sent_at    :datetime
 #  status     :integer          default("pending"), not null

--- a/test/models/notification_test.rb
+++ b/test/models/notification_test.rb
@@ -4,7 +4,7 @@
 #
 #  id         :bigint(8)        not null, primary key
 #  channel    :integer          default("email"), not null
-#  delay      :integer          not null
+#  interval      :integer          not null
 #  recipient  :string(255)      not null
 #  sent_at    :datetime
 #  status     :integer          default("pending"), not null

--- a/test/services/notifier/resolver_test.rb
+++ b/test/services/notifier/resolver_test.rb
@@ -27,9 +27,9 @@ module Notifier
       assert_includes notifications, n2
     end
 
-    test "#resolve_expires_soon gets only checks inside delay" do
-      n1 = create(:notification, check: build(:check, :expires_next_week), delay: 6)
-      n2 = create(:notification, check: build(:check, :expires_next_week), delay: 7)
+    test "#resolve_expires_soon gets only checks inside interval" do
+      n1 = create(:notification, check: build(:check, :expires_next_week), interval: 6)
+      n2 = create(:notification, check: build(:check, :expires_next_week), interval: 7)
 
       notifications = @resolver.resolve_expires_soon
 
@@ -39,9 +39,9 @@ module Notifier
 
     test "#resolve_expires_soon can gets several notifications for a same check" do
       check = create(:check, :expires_next_week)
-      n1 = create(:notification, check: check, delay: 3)
-      n2 = create(:notification, check: check, delay: 10)
-      n3 = create(:notification, check: check, delay: 30)
+      n1 = create(:notification, check: check, interval: 3)
+      n2 = create(:notification, check: check, interval: 10)
+      n3 = create(:notification, check: check, interval: 30)
 
       notifications = @resolver.resolve_expires_soon
 

--- a/test/system/checks_test.rb
+++ b/test/system/checks_test.rb
@@ -17,7 +17,7 @@ class ChecksTest < ApplicationSystemTestCase
 
     recipient = "recipient@example.org"
     fill_in("check[notifications_attributes][0][recipient]", with: recipient)
-    fill_in("check[notifications_attributes][0][delay]", with: 30)
+    fill_in("check[notifications_attributes][0][interval]", with: 30)
 
     click_button
 
@@ -28,7 +28,7 @@ class ChecksTest < ApplicationSystemTestCase
 
     notification = Notification.last
     assert_equal recipient, notification.recipient
-    assert_equal 30, notification.delay
+    assert_equal 30, notification.interval
     assert notification.email?
     assert notification.pending?
   end
@@ -67,7 +67,7 @@ class ChecksTest < ApplicationSystemTestCase
 
     recipient = "recipient2@example.org"
     fill_in("check[notifications_attributes][2][recipient]", with: recipient)
-    fill_in("check[notifications_attributes][2][delay]", with: 55)
+    fill_in("check[notifications_attributes][2][interval]", with: 55)
 
     assert_difference "Notification.where(check_id: #{@check.id}).count", +1 do
       click_button "Update Check"
@@ -79,7 +79,7 @@ class ChecksTest < ApplicationSystemTestCase
 
     notification = Notification.last
     assert_equal recipient, notification.recipient
-    assert_equal 55, notification.delay
+    assert_equal 55, notification.interval
     assert notification.email?
     assert notification.pending?
   end


### PR DESCRIPTION
From French to English "interval" is a better translation than "delay".
It's supposed to mean a number of days between two dates.