### PR TITLE
Add a top bar on each page to show the beta status.

### DIFF
--- a/app/frontend/scss/layout.scss
+++ b/app/frontend/scss/layout.scss
@@ -149,3 +149,27 @@ a.navbar-item.navbar-link {
     border: 1px solid  map-get($theme-colors, secondary);
   }
 }
+
+/*
+* === BETA BANNER ===
+*/
+
+.beta-banner {
+  background-color: #be0c04;
+}
+
+.beta-banner P {
+  margin-bottom: 0;
+  padding: 5px 20px 5px 20px;
+  color: #ffffff;
+  text-align: center;
+  font-size: 13px;
+}
+
+.beta-banner a {
+  color: #ffffff;
+  text-decoration: underline;
+}
+.beta-banner a:hover {
+  color: #d6b20e;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
   </head>
 
   <body>
+    <%= render 'shared/beta_banner' %>
     <%= render "shared/navbar" %>
     <% if params[:action] == 'home' %>
       <%= render 'shared/home_header' %>

--- a/app/views/shared/_beta_banner.html.erb
+++ b/app/views/shared/_beta_banner.html.erb
@@ -1,0 +1,4 @@
+<div class="container-fluid beta-banner">
+  <p><%= t(".beta_info")%> <%= t(".issue_link")%> <%= link_to(("https://github.com/Evolix/chexpire/issues/new"), "https://github.com/Evolix/chexpire/issues/new")%>
+  </p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,7 +75,9 @@ en:
     home_header: 
       welcome: "Chexpire"
       intro: "Never forget to renew a domain name or SSL certificate."
-    
+    beta_banner: 
+      beta_info: "Chexpire is now in \"beta\" release. Limitation: only major TLD (.com/.net/.org/.fr) are supported for domain name checks."
+      issue_link: "Please report issues to "
 
   pages:
     

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -107,6 +107,9 @@ fr:
     home_header: 
       welcome: "Chexpire"
       intro: "vous n'oublierez plus jamais de renouveler un nom de domaine ou un certificat SSL."
+    beta_banner: 
+      beta_info: "Chexpire est en version \"beta\". Limitation : seul les TLD principaux (.com/.net/.org/.fr) sont supportés pour les vérifications de nom de domaine."
+      issue_link: "Merci de reporter les bugs et suggestions via "
 
   pages:
     


### PR DESCRIPTION
fix #67 : 
Add a top bar on each page to show the "beta" status.