### PR TITLE
Detect language from HTTP headers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'bcrypt', '~> 3.1.7'
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 
+gem 'rack-contrib'
+
 gem 'open4'
 gem 'naught'
 gem 'hashie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,8 @@ GEM
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
+    rack-contrib (2.0.1)
+      rack (~> 2.0)
     rack-proxy (0.6.4)
       rack
     rack-test (1.1.0)
@@ -369,6 +371,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   pundit (~> 1.1)
+  rack-contrib
   rails (~> 5.2.0)
   rails-i18n (~> 5.1)
   rbnacl (>= 3.2, < 5.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    I18n.locale = current_user.try(:locale) || I18n.default_locale
+    I18n.locale = current_user.try(:locale) \
+      || request.env["rack.locale"].presence \
+      || I18n.default_locale
   end
 
   def not_found

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <% # Copyright (C) 2018 Colin Darie <colin@darie.eu>, 2018 Evolix <info@evolix.fr> %>
 <% # License: GNU AGPL-3+ (see full text in LICENSE file) %>
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <title>Chexpire</title>
     <%= csrf_meta_tags %>

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,6 @@
 
 require_relative "config/environment"
 
+use Rack::Locale
+
 run Rails.application


### PR DESCRIPTION
When there is no user logged in, we try to detect the desired locale from the HTTP `Accept-Language` header.

`Rack::Locale` (from the `rack-contrib` gem) implements the parsing and choice of a locale at the Rack middleware level. It respects the order of preferences. If a desired locale is in the list of available locales, it puts a `rack.locale` value in the Rack environment. It is then used by the application controller to set the global `I18n::Locale` value.

The locale is also added in the `lang` attribute of the `html` tag of the rendered layout.