### PR TITLE
check_http with --sni option

### DIFF
--- a/app/services/ssl.rb
+++ b/app/services/ssl.rb
@@ -58,8 +58,9 @@ module SSL
 
     def check_http_args
       [
-        "-C 0", # enable SSL mode without any delay warning
-        "-H",   # check_http does not works with fully quoted arg (check_http "-H myhost.org")
+        "-C 0",  # enable SSL mode without any delay warning
+        "--sni", # some certificates must have this option
+        "-H",    # check_http does not works with fully quoted arg (check_http "-H myhost.org")
         domain,
         *custom_check_http_args,
       ].compact

--- a/app/services/system_command.rb
+++ b/app/services/system_command.rb
@@ -44,7 +44,7 @@ class SystemCommand
 
     SystemCommandResult.new(
       syscmd,
-      status.exitstatus,
+      status.exitstatus || 255,
       stdout.read.strip,
       stderr.read.strip,
     )

--- a/config/chexpire.defaults.yml
+++ b/config/chexpire.defaults.yml
@@ -28,7 +28,9 @@ default: &default
   checks_ssl:
     interval: 0.0                              # pause in second between each check http call
     check_http_path:                           # defaults to check_http in $PATH
-    check_http_args:                           # array of arguments appended to defaults arguments (-C 0 -H $HOSTNAME).
+    check_http_args:                           # array of arguments *appended* after defaults arguments (which are -C 0 --sni -H $HOSTNAME)
+                                               # example: check_http_args: ["-4", "-I 127.0.0.1"]
+
 
 development:
   <<: *default

--- a/test/jobs/ssl_sync_job_test.rb
+++ b/test/jobs/ssl_sync_job_test.rb
@@ -81,6 +81,6 @@ class SSLSyncJobTest < ActiveJob::TestCase
   end
 
   def expected_command_arg(domain)
-    ["-C 0", "-H", domain]
+    ["-C 0", "--sni", "-H", domain]
   end
 end

--- a/test/services/check_ssl_processor_test.rb
+++ b/test/services/check_ssl_processor_test.rb
@@ -13,7 +13,7 @@ class CheckSSLProcessorTest < ActiveSupport::TestCase
     check = create(:check, :ssl, :nil_dates, domain: domain)
 
     response = file_fixture("ssl/ssl0.domain.org.txt").read
-    mock_system_command("check_http", ["-C 0", "-H", domain], stdout: response) do
+    mock_system_command("check_http", ["-C 0", "--sni", "-H", domain], stdout: response) do
       @processor.send(:process, check)
     end
 

--- a/test/services/ssl_test.rb
+++ b/test/services/ssl_test.rb
@@ -10,7 +10,7 @@ module SSL
     test "should run the command, return the result" do
       result = OpenStruct.new(exit_status: 0)
 
-      mock_system_klass("check_http", ["-C 0", "-H", "example.org"], result) do |system_klass|
+      mock_system_klass("check_http", standard_args, result) do |system_klass|
         service = Service.new("example.org", system_klass: system_klass)
         assert_equal result, service.run_command
       end
@@ -19,7 +19,7 @@ module SSL
     test "should raise an exception if exit status > 0" do
       result = OpenStruct.new(exit_status: 1)
 
-      mock_system_klass("check_http", ["-C 0", "-H", "example.org"], result) do |system_klass|
+      mock_system_klass("check_http", standard_args, result) do |system_klass|
         service = Service.new("example.org", system_klass: system_klass)
 
         assert_raises SSLCommandError do
@@ -42,7 +42,7 @@ module SSL
       result = OpenStruct.new(exit_status: 0)
       config = OpenStruct.new(check_http_args: ["-f", "-I 127.0.0.1"])
 
-      expected_args = ["-C 0", "-H", "example.org", "-f", "-I 127.0.0.1"]
+      expected_args = standard_args.concat ["-f", "-I 127.0.0.1"]
       mock_system_klass("check_http", expected_args, result) do |system_klass|
         service = Service.new("example.org", configuration: config, system_klass: system_klass)
         assert_equal result, service.run_command
@@ -63,10 +63,16 @@ module SSL
       result = OpenStruct.new(exit_status: 0)
       config = OpenStruct.new(check_http_path: "/usr/local/custom/path")
 
-      mock_system_klass("/usr/local/custom/path", ["-C 0", "-H", "example.org"], result) do |sys|
+      mock_system_klass("/usr/local/custom/path", standard_args, result) do |sys|
         service = Service.new("example.org", configuration: config, system_klass: sys)
         assert_equal result, service.run_command
       end
+    end
+
+    private
+
+    def standard_args
+      ["-C 0", "--sni", "-H", "example.org"]
     end
 
     def mock_system_klass(program, command_args, result)


### PR DESCRIPTION
- Support SNI by default
- intercepts system commands errors not propagated to ruby (i.e. check_http segfaults)
- `check_http_args` configuration more explicit

Closes #82
Probably fixes #74 ?