### PR TITLE
Output error summary for rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'octicons'
 gem 'kaminari'
 gem 'has_scope'
 
+gem 'logging'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,10 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -363,6 +367,7 @@ DEPENDENCIES
   launchy
   letter_opener_web
   listen (>= 3.0.5, < 3.2)
+  logging
   mysql2 (>= 0.4.4, < 0.6.0)
   naught
   octicons

--- a/app/services/check_domain_processor.rb
+++ b/app/services/check_domain_processor.rb
@@ -6,10 +6,6 @@ class CheckDomainProcessor
 
   protected
 
-  def configuration_key
-    "checks_domain"
-  end
-
   def resolvers
     %i[
       resolve_last_run_failed

--- a/app/services/check_ssl_processor.rb
+++ b/app/services/check_ssl_processor.rb
@@ -6,10 +6,6 @@ class CheckSSLProcessor
 
   protected
 
-  def configuration_key
-    "checks_ssl"
-  end
-
   def resolvers
     %i[
       resolve_all

--- a/lib/tasks/checks.rake
+++ b/lib/tasks/checks.rake
@@ -7,17 +7,21 @@ namespace :checks do
 
     desc "Refresh domains expiry dates"
     task domain: :environment do
+      logger = Logging.logger(STDOUT)
+      logger.level = :warn
       configuration = Rails.configuration.chexpire.fetch("checks_domain")
 
-      process = CheckDomainProcessor.new(configuration: configuration)
+      process = CheckDomainProcessor.new(logger: logger, configuration: configuration)
       process.sync_dates
     end
 
     desc "Refresh SSL expiry dates"
     task ssl: :environment do
+      logger = Logging.logger(STDOUT)
+      logger.level = :warn
       configuration = Rails.configuration.chexpire.fetch("checks_ssl")
 
-      process = CheckSSLProcessor.new(configuration: configuration)
+      process = CheckSSLProcessor.new(logger: logger, configuration: configuration)
       process.sync_dates
     end
   end

--- a/lib/tasks/checks.rake
+++ b/lib/tasks/checks.rake
@@ -1,27 +1,48 @@
 # Copyright (C) 2018 Colin Darie <colin@darie.eu>, 2018 Evolix <info@evolix.fr>
 # License: GNU AGPL-3+ (see full text in LICENSE file)
 
+require "null_logger"
+
 namespace :checks do
   namespace :sync_dates do
     task all: [:domain, :ssl]
 
+    def stdout_logger(env={})
+      verbose_mode = env.fetch("VERBOSE") { 0 }.to_i == 1
+      quiet_mode   = env.fetch("QUIET")   { 0 }.to_i == 1
+      silent_mode  = env.fetch("SILENT")  { 0 }.to_i == 1
+
+      if silent_mode
+        NullLogger.new 
+      else
+        logger = Logging.logger(STDOUT)
+        logger.level = if quiet_mode
+          :error
+        elsif verbose_mode
+          :debug
+        else
+          :info
+        end
+
+        logger
+      end
+    end
+
     desc "Refresh domains expiry dates"
     task domain: :environment do
-      logger = Logging.logger(STDOUT)
-      logger.level = :warn
-      configuration = Rails.configuration.chexpire.fetch("checks_domain")
-
-      process = CheckDomainProcessor.new(logger: logger, configuration: configuration)
+      process = CheckDomainProcessor.new(
+        logger: stdout_logger(ENV),
+        configuration: Rails.configuration.chexpire.fetch("checks_domain")
+      )
       process.sync_dates
     end
 
     desc "Refresh SSL expiry dates"
     task ssl: :environment do
-      logger = Logging.logger(STDOUT)
-      logger.level = :warn
-      configuration = Rails.configuration.chexpire.fetch("checks_ssl")
-
-      process = CheckSSLProcessor.new(logger: logger, configuration: configuration)
+      process = CheckSSLProcessor.new(
+        logger: stdout_logger(ENV),
+        configuration: Rails.configuration.chexpire.fetch("checks_ssl")
+      )
       process.sync_dates
     end
   end

--- a/lib/tasks/checks.rake
+++ b/lib/tasks/checks.rake
@@ -7,13 +7,17 @@ namespace :checks do
 
     desc "Refresh domains expiry dates"
     task domain: :environment do
-      process = CheckDomainProcessor.new
+      configuration = Rails.configuration.chexpire.fetch("checks_domain")
+
+      process = CheckDomainProcessor.new(configuration: configuration)
       process.sync_dates
     end
 
     desc "Refresh SSL expiry dates"
     task ssl: :environment do
-      process = CheckSSLProcessor.new
+      configuration = Rails.configuration.chexpire.fetch("checks_ssl")
+
+      process = CheckSSLProcessor.new(configuration: configuration)
       process.sync_dates
     end
   end

--- a/lib/tasks/checks.rake
+++ b/lib/tasks/checks.rake
@@ -7,13 +7,13 @@ namespace :checks do
   namespace :sync_dates do
     task all: [:domain, :ssl]
 
-    def stdout_logger(env={})
+    def stdout_logger(env = {}) # rubocop:disable Metrics/MethodLength
       verbose_mode = env.fetch("VERBOSE") { 0 }.to_i == 1
       quiet_mode   = env.fetch("QUIET")   { 0 }.to_i == 1
       silent_mode  = env.fetch("SILENT")  { 0 }.to_i == 1
 
       if silent_mode
-        NullLogger.new 
+        NullLogger.new
       else
         logger = Logging.logger(STDOUT)
         logger.level = if quiet_mode
@@ -32,7 +32,7 @@ namespace :checks do
     task domain: :environment do
       process = CheckDomainProcessor.new(
         logger: stdout_logger(ENV),
-        configuration: Rails.configuration.chexpire.fetch("checks_domain")
+        configuration: Rails.configuration.chexpire.fetch("checks_domain"),
       )
       process.sync_dates
     end
@@ -41,7 +41,7 @@ namespace :checks do
     task ssl: :environment do
       process = CheckSSLProcessor.new(
         logger: stdout_logger(ENV),
-        configuration: Rails.configuration.chexpire.fetch("checks_ssl")
+        configuration: Rails.configuration.chexpire.fetch("checks_ssl"),
       )
       process.sync_dates
     end

--- a/test/services/check_domain_processor_test.rb
+++ b/test/services/check_domain_processor_test.rb
@@ -5,7 +5,8 @@ require "test_helper"
 
 class CheckDomainProcessorTest < ActiveSupport::TestCase
   setup do
-    @processor = CheckDomainProcessor.new
+    configuration = Rails.configuration.chexpire.fetch("checks_domain")
+    @processor = CheckDomainProcessor.new(configuration: configuration)
   end
 
   test "process WhoisSyncJob for domain checks" do

--- a/test/services/check_processor_test.rb
+++ b/test/services/check_processor_test.rb
@@ -9,10 +9,6 @@ class CheckDummyProcessor
     base_scope
   end
 
-  def configuration_key
-    "checks_dummy"
-  end
-
   def resolvers
     %i[
       resolve_expire_short_term
@@ -23,7 +19,8 @@ end
 
 class CheckProcessorTest < ActiveSupport::TestCase
   setup do
-    @processor = CheckDummyProcessor.new
+    configuration = Rails.configuration.chexpire.fetch("checks_dummy")
+    @processor = CheckDummyProcessor.new(configuration: configuration)
   end
 
   test "resolve_last_run_failed includes already and never succeeded" do
@@ -119,7 +116,7 @@ class CheckProcessorTest < ActiveSupport::TestCase
       configuration.expect(:interval, 0.000001)
     end
 
-    processor = CheckDummyProcessor.new(configuration)
+    processor = CheckDummyProcessor.new(configuration: configuration)
 
     mock = Minitest::Mock.new
     assert_stub = lambda { |actual_time|

--- a/test/services/check_processor_test.rb
+++ b/test/services/check_processor_test.rb
@@ -108,19 +108,15 @@ class CheckProcessorTest < ActiveSupport::TestCase
   test "#sync_dates respects the interval configuration between sends" do
     create_list(:check, 3, :expires_next_week)
 
-    configuration = Minitest::Mock.new
-    2.times do configuration.expect(:long_term_interval, 300) end
-    configuration.expect(:long_term_frequency, 4)
-
-    3.times do
-      configuration.expect(:interval, 0.000001)
-    end
+    configuration = OpenStruct.new(long_term_interval: 300,
+                                   long_term_frequency: 4,
+                                   interval: 0.000001)
 
     processor = CheckDummyProcessor.new(configuration: configuration)
 
     mock = Minitest::Mock.new
     assert_stub = lambda { |actual_time|
-      assert_equal 0.000001, actual_time
+      assert_equal configuration.interval, actual_time
       mock
     }
 
@@ -130,7 +126,6 @@ class CheckProcessorTest < ActiveSupport::TestCase
       end
     end
 
-    configuration.verify
     mock.verify
   end
 end

--- a/test/services/check_ssl_processor_test.rb
+++ b/test/services/check_ssl_processor_test.rb
@@ -5,7 +5,8 @@ require "test_helper"
 
 class CheckSSLProcessorTest < ActiveSupport::TestCase
   setup do
-    @processor = CheckSSLProcessor.new
+    configuration = Rails.configuration.chexpire.fetch("checks_ssl")
+    @processor = CheckSSLProcessor.new(configuration: configuration)
   end
 
   test "process SSLSyncJob for ssl checks" do


### PR DESCRIPTION
Use the `logging`gem to add a logger to the rake task.
It can be configured with environment variables to display various amount of details, according to  these modes :

* `SILENT` : only fatal messages are displayed => currently none
* `QUIET` : errors (or above) => check errors
* _normal_ (no env variable set) : information (or above) => general timing and batch information
* `VERBOSE` : debug (or above) => a lot of information

Example: `$ QUIET=1 rake checks:sync_dates:domain`