### PR TITLE
Remove "in error" status of manual checks

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -116,7 +116,7 @@ class ChecksController < ApplicationController # rubocop:disable Metrics/ClassLe
     last_notification = @check.notifications.last
 
     # user has filled a new notification: we use it for the form
-    if last_notification.new_record?
+    if last_notification.present? && last_notification.new_record?
       @new_notification = last_notification
     else # otherwise, set a new empty notification
       build_empty_notification

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -128,7 +128,7 @@ class Check < ApplicationRecord
   end
 
   def reset_consecutive_failures
-    return unless last_success_at_changed?
+    return unless last_success_at_changed? || mode_changed? || domain_changed?
     return if consecutive_failures_changed?
 
     self.consecutive_failures = 0

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -87,7 +87,7 @@ class Check < ApplicationRecord
 
   def increment_consecutive_failures!
     self.consecutive_failures += 1
-    save!
+    save!(validate: false)
   end
 
   def supported?

--- a/test/models/check_test.rb
+++ b/test/models/check_test.rb
@@ -55,6 +55,27 @@ class CheckTest < ActiveSupport::TestCase
     assert_nil check_notification.sent_at
   end
 
+  test "consecutive failures are resetted when domain changed" do
+    check = create(:check, consecutive_failures: 1)
+
+    check.domain = "mynewdomain.fr"
+    check.save!
+
+    assert_equal 0, check.consecutive_failures
+  end
+
+  test "consecutive failures are resetted when mode changed" do
+    check = create(:check, consecutive_failures: 1, mode: :auto)
+    check.manual!
+
+    assert_equal 0, check.consecutive_failures
+
+    check = create(:check, domain: "x.wxyz", consecutive_failures: 1, mode: :manual)
+    check.auto!
+
+    assert_equal 0, check.consecutive_failures
+  end
+
   test "days_from_last_success without any success" do
     check = build(:check)
     assert_nil check.days_from_last_success


### PR DESCRIPTION
This concerns only checks when a domain name is updated, or when an current unsupported domain will be supported in the future.