### PR TITLE
sign-in/out vs. log-in/out and localization on the home page

### DIFF
--- a/app/views/shared/_home_header.html.erb
+++ b/app/views/shared/_home_header.html.erb
@@ -6,8 +6,8 @@
                 <p><%= t(".intro") %></p>
             </div>
             <div class="d-flex flex-wrap justify-content-around align-items-center">
-                <%= link_to "Learn More", root_path(@root, anchor: "description"), :class => "btn btn-primary" %>
-                <%= link_to "Sign Up", new_user_registration_path, :class => "btn btn-tertiary" %>
+                <%= link_to t(".actions.learn_more"), root_path(@root, anchor: "description"), :class => "btn btn-primary" %>
+                <%= link_to t(".actions.sign_up"), new_user_registration_path, :class => "btn btn-tertiary" %>
             </div>
         </div>
     </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -46,7 +46,7 @@
 
                 <%= link_to destroy_user_session_path, method: :delete, class: "dropdown-item" do %>
                 <i class="fa fa-sign-out"></i>
-                <%= t(".sign_out", default: "Log out") %>
+                <%= t(".sign_out", default: "Sign out") %>
               <% end %>
             </div>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,9 @@ en:
     home_header:
       welcome: "Chexpire"
       intro: "Never forget to renew a domain name or SSL certificate."
+      actions:
+        learn_more: "Learn More"
+        sign_up: "Sign Up"
     beta_banner:
       beta_info: "Chexpire is in \"beta\" release: only few TLD (.com/.net/.org/.fr) are verified for domain name checks and TLS 1.2 is not supported for SSL checks."
       issue_link: "Please report issues."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,8 +91,8 @@ en:
       new_ssl_check: "New SSL check"
       my_notifications: "My notifications"
       sign_up: "Sign up"
-      sign_in: "Log in"
-      sign_out: "Log out"
+      sign_in: "Sign in"
+      sign_out: "Sign out"
       profile: "Profile"
     home_header:
       welcome: "Chexpire"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -119,13 +119,16 @@ fr:
       new_domain_check: "Nouveau nom de domaine"
       new_ssl_check: "Nouveau certificat SSL"
       my_notifications: "Mes notifications"
-      sign_up: "Enregistrement"
+      sign_up: "Inscription"
       sign_in: "Connexion"
       sign_out: "Déconnexion"
       profile: "Profil"
     home_header:
       welcome: "Chexpire"
       intro: "vous n'oublierez plus jamais de renouveler un nom de domaine ou un certificat SSL."
+      actions:
+        learn_more: "En savoir plus"
+        sign_up: "S'inscrire"
     beta_banner:
       beta_info: "Chexpire est en version \"beta\" : seuls certains TLD (.com/.net/.org/.fr) sont vérifiés pour les noms de domaine et TLS 1.2 n'est pas supporté pour les vérifications SSL."
       issue_link: "Merci de nous reporter bugs et suggestions."


### PR DESCRIPTION
"sign in" and "sign out" seem to be more widely used than "log-in" and "log-out".
And it seems better to have consistent terms with "sign-up".

Also, the terms on the home page should be localized.